### PR TITLE
feat: add tailwind v4 conversion mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - 🪶 **Lightweight**: Zero dependencies, optimized for performance
 - 🌐 **Browser Compatible**: Works in both Node.js and browser environments
 - 🐛 **Debug Mode**: Built-in debugging for troubleshooting conversions
+- 🆕 **Tailwind v4 Mode**: Optional canonical output for current Tailwind docs utility syntax
 
 ## 📦 Installation
 
@@ -33,14 +34,14 @@ pnpm add transform-to-tailwindcss-core
 ## 🚀 Quick Start
 
 ```typescript
-import { transformStyleToTailwindcss } from 'transform-to-tailwindcss-core'
+import { toTailwindcss, transformStyleToTailwindcss } from 'transform-to-tailwindcss-core'
 
 // Basic usage
 const [tailwindClasses, unconverted] = transformStyleToTailwindcss(
   'color: red; font-size: 16px; margin: 10px'
 )
 
-console.log(tailwindClasses) // "text-red-500 text-base m-2.5"
+console.log(tailwindClasses) // "text-[red] text-[16px] m-[10px]"
 console.log(unconverted) // [] (empty if all styles converted)
 
 // With rem units
@@ -55,11 +56,16 @@ const [classes, unconverted] = transformStyleToTailwindcss(
   false, // rem conversion
   true // debug mode - shows conversion process
 )
+
+// Tailwind v4 canonical output
+console.log(toTailwindcss('aspect-ratio: 1 / 1;', false, true)) // "aspect-square"
+console.log(toTailwindcss('width: 100%;', false, true)) // "w-full"
+console.log(toTailwindcss('rotate: 45deg;', false, true)) // "rotate-45"
 ```
 
 ## 📖 API Reference
 
-### `transformStyleToTailwindcss(styles, isRem?, debug?)`
+### `transformStyleToTailwindcss(styles, isRem?, debug?, isV4?)`
 
 Converts CSS styles to Tailwind CSS utility classes.
 
@@ -68,12 +74,48 @@ Converts CSS styles to Tailwind CSS utility classes.
 - `styles` (string): CSS styles to convert (e.g., "color: red; font-size: 16px")
 - `isRem` (boolean, optional): Whether to convert pixel values to rem units
 - `debug` (boolean, optional): Enable debug logging to see conversion process
+- `isV4` (boolean, optional): Prefer Tailwind v4 canonical utility output for supported property pages
 
 #### Returns
 
 Returns a tuple `[string, string[]]`:
 - First element: Converted Tailwind CSS classes as a string
 - Second element: Array of unconverted CSS styles
+
+### `toTailwindcss(css, isRem?, isV4?)`
+
+Converts a single CSS declaration to a Tailwind utility string.
+
+#### Parameters
+
+- `css` (string): A single CSS declaration (e.g. `"aspect-ratio: 1 / 1;"`)
+- `isRem` (boolean, optional): Whether to convert pixel values to rem units
+- `isV4` (boolean, optional): Prefer Tailwind v4 canonical utility output for supported property pages
+
+#### Examples
+
+```typescript
+toTailwindcss('aspect-ratio: 1 / 1;') // "aspect-[1/1]"
+toTailwindcss('aspect-ratio: 1 / 1;', false, true) // "aspect-square"
+
+toTailwindcss('line-clamp: 3;', false, true) // "line-clamp-3"
+toTailwindcss('color-scheme: light dark;', false, true) // "scheme-light-dark"
+```
+
+### Tailwind v4 Mode
+
+`isV4` is opt-in so existing integrations keep the current output by default.
+
+When `isV4` is `true`, the converter prefers current Tailwind documentation syntax for supported utilities, for example:
+
+```typescript
+toTailwindcss('aspect-ratio: var(--aspect-video);', false, true) // "aspect-video"
+toTailwindcss('inline-size: 100%;', false, true) // "inline-full"
+toTailwindcss('block-size: 100vh;', false, true) // "block-screen"
+toTailwindcss('font-stretch: condensed;', false, true) // "font-stretch-condensed"
+toTailwindcss('text-shadow: none;', false, true) // "text-shadow-none"
+toTailwindcss('translate: 100% 100%;', false, true) // "translate-full"
+```
 
 ## 🎯 Supported CSS Properties
 
@@ -89,6 +131,8 @@ This library supports a wide range of CSS properties including:
 - **Borders**: `border`, `border-width`, `border-radius`
 - **Effects**: `box-shadow`, `opacity`, `transform`
 - **And many more...**
+
+Tailwind v4 mode also covers current property-page syntax across the Tailwind docs categories such as Layout, Flexbox & Grid, Sizing, Typography, Backgrounds, Borders, Effects, Filters, Tables, Transitions & Animation, Transforms, Interactivity, SVG, and Accessibility.
 
 ## 🔧 Advanced Usage
 

--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -1,14 +1,31 @@
-import { getFirstName, getVal, transformImportant } from './utils'
+import { getCustomPropertyName, getFirstName, getVal, normalizeFraction, transformImportant } from './utils'
 
 const aspectMap = [
   'aspect-ratio',
 ]
-export function aspect(key: string, val: string) {
+export function aspect(key: string, val: string, isV4?: boolean) {
   if (!aspectMap.includes(key))
     return
   const [value, important] = transformImportant(val)
+  const prefix = getFirstName(key)
 
   if (value === 'auto')
-    return `${important}${getFirstName(key)}-${value}`
-  return `${important}${getFirstName(key)}${getVal(value)}`
+    return `${important}${prefix}-${value}`
+
+  if (isV4) {
+    const customProperty = getCustomPropertyName(value)
+    if (customProperty) {
+      if (customProperty === '--aspect-video')
+        return `${important}aspect-video`
+      return `${important}aspect-(${customProperty})`
+    }
+
+    const normalized = normalizeFraction(value)
+    if (normalized === '1/1')
+      return `${important}aspect-square`
+    if (/^\d+\/\d+$/.test(normalized))
+      return `${important}aspect-${normalized}`
+  }
+
+  return `${important}${prefix}${getVal(value)}`
 }

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,10 +1,16 @@
-import { getVal, transformImportant } from './utils'
+import { getVal, joinWithLine, transformImportant } from './utils'
 
-const colorMap = ['color']
-export function color(key: string, val: string) {
+const colorMap = ['color', 'color-scheme']
+export function color(key: string, val: string, isV4?: boolean) {
   if (!colorMap.includes(key))
     return
   const [value, important] = transformImportant(val)
+
+  if (key === 'color-scheme') {
+    if (!isV4)
+      return
+    return `${important}scheme-${joinWithLine(value)}`
+  }
 
   return `${important}text${getVal(value)}`
 }

--- a/src/font.ts
+++ b/src/font.ts
@@ -1,16 +1,30 @@
-import { getVal, joinWithUnderLine, transformImportant } from './utils'
+import { getCustomPropertyName, getVal, joinWithUnderLine, transformImportant } from './utils'
 
 const fontMap = [
   'font',
   'font-size',
+  'font-feature-settings',
   'font-smoothing',
+  'font-stretch',
   'font-weight',
   'font-family',
   'font-style',
   'font-variant-numeric',
   'osx-font-smoothing',
 ]
-export function font(key: string, val: string) {
+const stretchMap = new Set([
+  'ultra-condensed',
+  'extra-condensed',
+  'condensed',
+  'semi-condensed',
+  'normal',
+  'semi-expanded',
+  'expanded',
+  'extra-expanded',
+  'ultra-expanded',
+])
+
+export function font(key: string, val: string, isV4?: boolean) {
   const [value, important] = transformImportant(val)
 
   if (key === 'font-size') {
@@ -20,12 +34,30 @@ export function font(key: string, val: string) {
   }
   if (key === 'font-weight')
     return `${important}font-[weight:${value}]`
+  if (key === 'font-feature-settings') {
+    if (!isV4)
+      return
+    const customProperty = getCustomPropertyName(value)
+    if (customProperty)
+      return `${important}font-features-(${customProperty})`
+    return `${important}font-features-[${value}]`
+  }
   if (key === 'font-smoothing' || key === 'osx-font-smoothing') {
     if (value === 'auto')
       return `${important}subpixel-antialiased`
     if (value === 'antialiased' || value === 'grayscale')
       return `${important}antialiased`
     return
+  }
+  if (key === 'font-stretch') {
+    if (!isV4)
+      return
+    const customProperty = getCustomPropertyName(value)
+    if (customProperty)
+      return `${important}font-stretch-(${customProperty})`
+    if (stretchMap.has(value) || /^\d+(?:\.\d+)?%$/.test(value))
+      return `${important}font-stretch-${value}`
+    return `${important}font-stretch${getVal(value)}`
   }
   if (key === 'font-family') {
     const match = value.match(/ui-(\w{0,4})/)!

--- a/src/line.ts
+++ b/src/line.ts
@@ -1,4 +1,4 @@
-import { getVal, transformImportant } from './utils'
+import { getCustomPropertyName, getVal, transformImportant } from './utils'
 
 const lineKey: Record<string, string> = {
   1: 'none',
@@ -9,12 +9,27 @@ const lineKey: Record<string, string> = {
   2: 'loose',
 }
 const lineMap = [
+  'line-clamp',
   'line-height',
 ]
-export function line(key: string, val: string) {
+export function line(key: string, val: string, isV4?: boolean) {
   if (!lineMap.includes(key))
     return
   const [value, important] = transformImportant(val)
+
+  if (key === 'line-clamp') {
+    if (value === 'none' || value === 'unset')
+      return `${important}line-clamp-none`
+
+    const customProperty = getCustomPropertyName(value)
+    if (isV4 && customProperty)
+      return `${important}line-clamp-(${customProperty})`
+
+    if (/^\d+$/.test(value))
+      return `${important}line-clamp-${value}`
+
+    return `${important}line-clamp${getVal(value)}`
+  }
 
   if (lineKey[value])
     return `${important}leading-${lineKey[value]}`

--- a/src/max.ts
+++ b/src/max.ts
@@ -1,4 +1,4 @@
-import { getFirstName, getVal, isCalc, isVar, transformImportant } from './utils'
+import { getCustomPropertyName, getFirstName, getVal, isCalc, isVar, normalizeFraction, transformImportant } from './utils'
 
 const maxMap = [
   'max-height',
@@ -10,14 +10,60 @@ const maxMap = [
   'min-block-size',
   'min-inline-size',
 ]
-export function max(key: string, val: string) {
+const prefixMap: Record<string, string> = {
+  'max-height': 'max-h',
+  'max-width': 'max-w',
+  'max-block-size': 'max-block',
+  'max-inline-size': 'max-inline',
+  'min-height': 'min-h',
+  'min-width': 'min-w',
+  'min-block-size': 'min-block',
+  'min-inline-size': 'min-inline',
+}
+
+export function max(key: string, val: string, isV4?: boolean) {
   if (!maxMap.includes(key))
     return
+  if (!isV4 && /(?:inline|block)-size$/.test(key))
+    return
   const [value, important] = transformImportant(val)
+  const prefix = prefixMap[key]
 
-  const all = key.split('-')
-  // calc value has '-'
-  // getFirstName causes the value to be lost
+  if (isV4) {
+    const customProperty = getCustomPropertyName(value)
+    if (customProperty)
+      return `${important}${prefix}-(${customProperty})`
+
+    const normalized = normalizeFraction(value)
+    if (/^\d+\/\d+$/.test(normalized))
+      return `${important}${prefix}-${normalized}`
+
+    const alias = getSizeAlias(key, value)
+    if (alias)
+      return `${important}${prefix}-${alias}`
+  }
+
   const attributeValue = (isCalc(value) || isVar(value)) ? getVal(value) : getVal(getFirstName(value))
-  return `${important}${all[0]}-${all[1][0]}${attributeValue}`
+  return `${important}${prefix}${attributeValue}`
+}
+
+function getSizeAlias(key: string, value: string) {
+  const viewportKey = /width|inline/.test(key) ? '100vw' : '100vh'
+  const map: Record<string, string> = {
+    'auto': 'auto',
+    '1px': 'px',
+    '100%': 'full',
+    [viewportKey]: 'screen',
+    '100dvw': 'dvw',
+    '100dvh': 'dvh',
+    '100lvw': 'lvw',
+    '100lvh': 'lvh',
+    '100svw': 'svw',
+    '100svh': 'svh',
+    'min-content': 'min',
+    'max-content': 'max',
+    'fit-content': 'fit',
+    'none': 'none',
+  }
+  return map[value]
 }

--- a/src/size.ts
+++ b/src/size.ts
@@ -1,13 +1,59 @@
-import { getFirstName, getVal, isDynamic, transformImportant } from './utils'
+import { getCustomPropertyName, getFirstName, getVal, isDynamic, normalizeFraction, transformImportant } from './utils'
 
 const sizeMap = [
   'width',
   'height',
+  'inline-size',
+  'block-size',
 ]
-export function size(key: string, val: string) {
+const prefixMap: Record<string, string> = {
+  'width': 'w',
+  'height': 'h',
+  'inline-size': 'inline',
+  'block-size': 'block',
+}
+
+export function size(key: string, val: string, isV4?: boolean) {
   if (!sizeMap.includes(key))
     return
+  if (!isV4 && ['inline-size', 'block-size'].includes(key))
+    return
   const [value, important] = transformImportant(val)
+  const prefix = prefixMap[key]
 
-  return `${important}${key[0]}${getVal(value, isDynamic(value) ? undefined : getFirstName)}`
+  if (isV4) {
+    const customProperty = getCustomPropertyName(value)
+    if (customProperty)
+      return `${important}${prefix}-(${customProperty})`
+
+    const normalized = normalizeFraction(value)
+    if (/^\d+\/\d+$/.test(normalized))
+      return `${important}${prefix}-${normalized}`
+
+    const alias = getSizeAlias(key, value)
+    if (alias)
+      return `${important}${prefix}-${alias}`
+  }
+
+  return `${important}${prefix}${getVal(value, isDynamic(value) ? undefined : getFirstName)}`
+}
+
+function getSizeAlias(key: string, value: string) {
+  const viewportKey = ['width', 'inline-size'].includes(key) ? '100vw' : '100vh'
+  const map: Record<string, string> = {
+    'auto': 'auto',
+    '1px': 'px',
+    '100%': 'full',
+    [viewportKey]: 'screen',
+    '100dvw': 'dvw',
+    '100dvh': 'dvh',
+    '100lvw': 'lvw',
+    '100lvh': 'lvh',
+    '100svw': 'svw',
+    '100svh': 'svh',
+    'min-content': 'min',
+    'max-content': 'max',
+    'fit-content': 'fit',
+  }
+  return map[value]
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,4 +1,4 @@
-import { getVal, positionMap, transformImportant } from './utils'
+import { getCustomPropertyName, getVal, joinWithUnderLine, positionMap, transformImportant } from './utils'
 
 const textMap = [
   'text-align',
@@ -16,7 +16,7 @@ const textMap = [
   'text-justify',
   'text-shadow',
 ]
-export function text(key: string, val: string) {
+export function text(key: string, val: string, isV4?: boolean) {
   if (!textMap.includes(key))
     return
   const [value, important] = transformImportant(val)
@@ -35,6 +35,17 @@ export function text(key: string, val: string) {
 
   if (key === 'text-decoration') {
     return value.split(' ').map(v => v ? `${important}${v}` : '').join(' ')
+  }
+
+  if (key === 'text-shadow') {
+    if (!isV4)
+      return `${important}text${getVal(value)}`
+    if (value === 'none')
+      return `${important}text-shadow-none`
+    const customProperty = getCustomPropertyName(value)
+    if (customProperty)
+      return `${important}text-shadow-(${customProperty})`
+    return `${important}text-shadow-[${joinWithUnderLine(value)}]`
   }
 
   if (key.startsWith('text-decoration') || key === 'text-indent')

--- a/src/toTailwindcss.ts
+++ b/src/toTailwindcss.ts
@@ -85,11 +85,13 @@ const typeMap: any = {
   align,
   place,
   padding: transformMargin,
-  perspective: float,
+  perspective: transform,
   margin: transformMargin,
+  inline: size,
   width: size,
   min: max,
   max,
+  block: size,
   height: size,
   font,
   letter,
@@ -110,6 +112,10 @@ const typeMap: any = {
   table: list,
   transition,
   transform,
+  rotate: transform,
+  scale: transform,
+  skew: transform,
+  translate: transform,
   accent: list,
   appearance: list,
   cursor,
@@ -127,14 +133,14 @@ const typeMap: any = {
 }
 const splitReg = /([\w-]+)\s*:\s*([^;]+)/
 
-export function toTailwindcss(css: string, isRem?: boolean) {
+export function toTailwindcss(css: string, isRem?: boolean, isV4?: boolean) {
   css = css.replace(browserReg, '')
   const match = css.match(splitReg)
   if (!match)
     return
   const [_, key, val] = match
   const first = getFirstName(key)
-  const result = typeMap[first]?.(key, val)
+  const result = typeMap[first]?.(key, val, isV4)
   if (result && isRem) {
     return result.replace(
       /-\[([0-9.]+)px\]/g,

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,4 +1,5 @@
 import {
+  getCustomPropertyName,
   getHundred,
   getVal,
   isCalc,
@@ -13,69 +14,263 @@ const transformMap = [
   'transform',
   'transform-origin',
   'transform-style',
+  'perspective',
+  'perspective-origin',
+  'rotate',
+  'scale',
+  'skew',
+  'translate',
 ]
-export function transform(key: string, val: string) {
+
+export function transform(key: string, val: string, isV4?: boolean) {
   if (!transformMap.includes(key))
     return
+
   const [v, important] = transformImportant(val)
+
   if (key === 'transform-origin') {
     if (isVar(v) || isCalc(v))
       return `${important}origin${getVal(v)}`
     return `${important}origin-${/\d/.test(v) && v.includes(' ') ? `[${joinWithUnderLine(v)}]` : joinWithLine(v)}`
   }
+
   if (key === 'transform-style')
     return `${important}transform-${v}`
-  if (val === 'none')
+
+  if (key === 'perspective')
+    return getBaseUtility('perspective', v, important, isV4)
+
+  if (key === 'perspective-origin') {
+    if (!isV4)
+      return
+    return getBaseUtility('perspective-origin', v, important, isV4)
+  }
+
+  if (key === 'rotate')
+    return getRotateUtility(v, important, isV4)
+
+  if (key === 'scale')
+    return getScaleUtility(splitTransformValues(v), important, isV4)
+
+  if (key === 'skew')
+    return getSkewUtility(splitTransformValues(v), important, isV4)
+
+  if (key === 'translate')
+    return getTranslateUtility(splitTransformValues(v), important, isV4, true)
+
+  if (v === 'none')
     return `${important}${key}-none`
 
   return joinEmpty(v)
     .split(' ')
-    .map((v) => {
-      const matcher = v.match(/([a-z]+)(3d)?([A-Z])?\((.*)\)/)
+    .map((item) => {
+      const matcher = item.match(/([a-z]+)(3d)?([A-Z])?\((.*)\)/)
       if (!matcher)
         return undefined
-      const [_, namePrefix, is3d, nameSuffix, value] = matcher
-      if (nameSuffix) {
-        const values = value.replace(
-          /,(?![^()]*\))/g,
-          ' ',
-        ).split(' ')
-        if (values.length > 1) {
-          return `${important}${namePrefix}-[${nameSuffix.toLowerCase()}-${values.map((v) => {
-            return isVar(v)
-              ? v
-              : getVal(
-                  namePrefix === 'scale' ? getHundred(v) : v,
-                )
-          }).join('_')}]`
-        }
 
-        return `${important}${namePrefix}-${nameSuffix.toLowerCase()}${isVar(values[0])
-          ? `-[${values[0]}]`
-          : getVal(
-              namePrefix === 'scale' ? getHundred(values[0]) : values[0],
-            )}`
-      }
-      else {
-        const values = value.replace(
-          /,(?![^()]*\))/g,
-          ' ',
-        ).split(' ')
-        if (namePrefix === 'scale') {
-          if (values.length > 1)
-            return `${important}${namePrefix}-[${values.join('_')}]`
-          return `${important}${namePrefix}${isVar(value) || isCalc(value)
-            ? `-[${value}]`
-            : getVal(
-                namePrefix === 'scale' ? getHundred(value) : value,
-              )}`
-        }
-        const [x, y] = values
-        return `${important}${namePrefix}-x${getVal(
-          x,
-        )} ${important}${namePrefix}-y${getVal(y ?? x)}`
-      }
+      const [_, namePrefix, _is3d, nameSuffix, value] = matcher
+      const values = splitTransformValues(value)
+      const axis = nameSuffix?.toLowerCase()
+
+      if (namePrefix === 'rotate')
+        return getRotateUtility(values[0], important, isV4, axis)
+      if (namePrefix === 'scale')
+        return getScaleUtility(values, important, isV4, axis)
+      if (namePrefix === 'translate')
+        return getTranslateUtility(values, important, isV4, false, axis)
+      if (namePrefix === 'skew')
+        return getSkewUtility(values, important, isV4, axis)
+      return undefined
     })
     .filter(Boolean)
     .join(' ')
+}
+
+function splitTransformValues(value: string) {
+  return joinEmpty(value)
+    .replace(
+      /,(?![^()]*\))/g,
+      ' ',
+    )
+    .split(' ')
+    .filter(Boolean)
+}
+
+function getBaseUtility(prefix: string, value: string, important: string, isV4?: boolean) {
+  const customProperty = getCustomPropertyName(value)
+  if (isV4 && customProperty)
+    return `${important}${prefix}-(${customProperty})`
+  if (prefix === 'perspective-origin' && value.includes(' ')) {
+    if (!/\d/.test(value) && !isVar(value) && !isCalc(value))
+      return `${important}${prefix}-${joinWithLine(value)}`
+    return `${important}${prefix}-[${joinWithUnderLine(value)}]`
+  }
+  return `${important}${prefix}${getVal(value)}`
+}
+
+function getRotateUtility(value: string, important: string, isV4?: boolean, axis?: string) {
+  const prefix = axis ? `rotate-${axis}` : 'rotate'
+  if (!axis && value === 'none')
+    return `${important}rotate-none`
+
+  const customProperty = getCustomPropertyName(value)
+  if (isV4 && customProperty)
+    return `${important}${prefix}-(${customProperty})`
+
+  const simpleAngle = getSimpleAngle(value)
+  if (isV4 && simpleAngle) {
+    const [negative, amount] = simpleAngle
+    return `${important}${negative ? '-' : ''}${prefix}-${amount}`
+  }
+
+  return `${important}${prefix}${getVal(value)}`
+}
+
+function getScaleUtility(values: string[], important: string, isV4?: boolean, axis?: string): string {
+  const prefix = axis ? `scale-${axis}` : 'scale'
+  if (!axis && values[0] === 'none')
+    return `${important}scale-none`
+
+  if (values.length > 1) {
+    if (!axis && values.every(value => value === values[0]))
+      return getScaleUtility([values[0]], important, isV4)
+    return `${important}${prefix}-[${values.join('_')}]`
+  }
+
+  const value = values[0]
+  const customProperty = getCustomPropertyName(value)
+  if (isV4 && customProperty)
+    return `${important}${prefix}-(${customProperty})`
+
+  const scaleAmount = getScaleAmount(value)
+  if (isV4 && scaleAmount) {
+    const [negative, amount] = scaleAmount
+    return `${important}${negative ? '-' : ''}${prefix}-${amount}`
+  }
+
+  return `${important}${prefix}${isVar(value) || isCalc(value)
+    ? `-[${value}]`
+    : getVal(getHundred(value))}`
+}
+
+function getTranslateUtility(
+  values: string[],
+  important: string,
+  isV4?: boolean,
+  isDirectProperty = false,
+  axis?: string,
+) {
+  if (axis)
+    return getTranslateAxisUtility(axis, values[0], important, isV4)
+
+  if (values[0] === 'none')
+    return `${important}translate-none`
+
+  if (values.length > 1) {
+    if (isV4 && values.every(value => value === values[0]))
+      return getTranslatePairUtility(values[0], important, isV4)
+
+    return values
+      .slice(0, 3)
+      .map((value, index) => getTranslateAxisUtility(['x', 'y', 'z'][index], value, important, isV4))
+      .join(' ')
+  }
+
+  if (!isDirectProperty)
+    return getTranslateAxisUtility('x', values[0], important, isV4)
+
+  return getTranslatePairUtility(values[0], important, isV4)
+}
+
+function getTranslatePairUtility(value: string, important: string, isV4?: boolean) {
+  const customProperty = getCustomPropertyName(value)
+  if (isV4 && customProperty)
+    return `${important}translate-(${customProperty})`
+
+  const alias = getTranslateAlias(value)
+  if (isV4 && alias)
+    return `${important}${alias[0] ? '-' : ''}translate-${alias[1]}`
+
+  return `${important}translate${getVal(value)}`
+}
+
+function getTranslateAxisUtility(axis: string, value: string, important: string, isV4?: boolean) {
+  const prefix = `translate-${axis}`
+  const customProperty = getCustomPropertyName(value)
+  if (isV4 && customProperty)
+    return `${important}${prefix}-(${customProperty})`
+
+  const alias = getTranslateAlias(value)
+  if (isV4 && alias)
+    return `${important}${alias[0] ? '-' : ''}${prefix}-${alias[1]}`
+
+  return `${important}${prefix}${getVal(value)}`
+}
+
+function getSkewUtility(values: string[], important: string, isV4?: boolean, axis?: string): string {
+  if (axis)
+    return getSkewAxisUtility(axis, values[0], important, isV4)
+
+  if (values.length > 1) {
+    return values
+      .slice(0, 2)
+      .map((value, index) => getSkewAxisUtility(['x', 'y'][index], value, important, isV4))
+      .join(' ')
+  }
+
+  return getSkewAxisUtility('x', values[0], important, isV4)
+}
+
+function getSkewAxisUtility(axis: string, value: string, important: string, isV4?: boolean) {
+  const prefix = `skew-${axis}`
+  const customProperty = getCustomPropertyName(value)
+  if (isV4 && customProperty)
+    return `${important}${prefix}-(${customProperty})`
+
+  const simpleAngle = getSimpleAngle(value)
+  if (isV4 && simpleAngle) {
+    const [negative, amount] = simpleAngle
+    return `${important}${negative ? '-' : ''}${prefix}-${amount}`
+  }
+
+  return `${important}${prefix}${getVal(value)}`
+}
+
+function getSimpleAngle(value: string) {
+  const match = value.match(/^(-?)(\d+)deg$/)
+  if (!match)
+    return
+  return [match[1] === '-', match[2]] as const
+}
+
+function getScaleAmount(value: string) {
+  if (value === '0')
+    return [false, '0'] as const
+  if (/^-?\d+$/.test(value))
+    return [value.startsWith('-'), String(Math.abs(Number(value) * 100))] as const
+
+  const match = value.match(/^(-?)(\d*\.?\d+)$/)
+  if (match) {
+    const amount = Number.parseFloat(match[2]) * 100
+    if (Number.isInteger(amount))
+      return [match[1] === '-', String(amount)] as const
+  }
+
+  const percentMatch = value.match(/^(-?)(\d+(?:\.\d+)?)%$/)
+  if (percentMatch && !percentMatch[2].includes('.'))
+    return [percentMatch[1] === '-', percentMatch[2]] as const
+}
+
+function getTranslateAlias(value: string) {
+  if (value === '1px')
+    return [false, 'px'] as const
+  if (value === '-1px')
+    return [true, 'px'] as const
+  if (value === '100%')
+    return [false, 'full'] as const
+  if (value === '-100%')
+    return [true, 'full'] as const
+  if (/^-?\d+\/\d+$/.test(value)) {
+    return [value.startsWith('-'), value.replace(/^-/, '')] as const
+  }
 }

--- a/src/transformStyleToTailwindcss.ts
+++ b/src/transformStyleToTailwindcss.ts
@@ -6,6 +6,7 @@ export function transformStyleToTailwindcss(
   styles: string,
   isRem?: boolean,
   debug?: boolean,
+  isV4?: boolean,
 ): [string, string[]] {
   const log = debug ? console.log : () => {}
 
@@ -15,7 +16,7 @@ export function transformStyleToTailwindcss(
   // 如果存在未能被转换的style应该返回并保持部分的style
   const noTransfer: string[] = []
   const cache = new Set()
-  const { newStyle, transformedResult } = transformStyleToTailwindPre(styles)
+  const { newStyle, transformedResult } = transformStyleToTailwindPre(styles, isV4)
 
   log('🔍 [DEBUG] After transformStyleToTailwindPre:', { newStyle, transformedResult })
 
@@ -33,7 +34,7 @@ export function transformStyleToTailwindcss(
         }
         cache.add(key)
 
-        const val = toTailwindcss(key, isRem) || ''
+        const val = toTailwindcss(key, isRem, isV4) || ''
         log('🔍 [DEBUG] Converted to Tailwind:', key, '->', val)
 
         if (!val) {
@@ -65,7 +66,7 @@ export function transformStyleToTailwindcss(
       }
       cache.add(key)
 
-      const val = toTailwindcss(key, isRem) || ''
+      const val = toTailwindcss(key, isRem, isV4) || ''
       log('🔍 [DEBUG] Converted to Tailwind:', key, '->', val)
 
       if (!val) {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,3 +1,5 @@
+import { getCustomPropertyName, getVal } from './utils'
+
 // 找到第一个不在方括号内的冒号位置
 function findFirstColonOutsideBrackets(str: string): number {
   let bracketDepth = 0
@@ -21,9 +23,9 @@ function createRuleProcessor(config: {
   allMatch: Record<string, string | RegExp>
   anyMatch?: Array<{ key: string, pattern: RegExp | string }>
   priority?: string[]
-  outputTemplate: string | ((value: string) => string)
+  outputTemplate: string | ((value: string, isV4?: boolean) => string)
 }) {
-  return (v: Record<string, string>): { transformedResult: string, deleteKeys: string[] } => {
+  return (v: Record<string, string>, isV4?: boolean): { transformedResult: string, deleteKeys: string[] } => {
     // 规范化配置，确保所有字段都存在
     const anyMatch = config.anyMatch || []
     const priority = config.priority || []
@@ -78,7 +80,7 @@ function createRuleProcessor(config: {
 
     // 生成输出结果
     const transformedResult = typeof config.outputTemplate === 'function'
-      ? config.outputTemplate(valueToUse)
+      ? config.outputTemplate(valueToUse, isV4)
       // eslint-disable-next-line no-template-curly-in-string
       : config.outputTemplate.replace('${value}', valueToUse)
 
@@ -89,7 +91,7 @@ function createRuleProcessor(config: {
   }
 }
 
-const transformer: Record<string, (v: Record<string, string>) => { transformedResult: string, deleteKeys: string[] }> = {
+const transformer: Record<string, (v: Record<string, string>, isV4?: boolean) => { transformedResult: string, deleteKeys: string[] }> = {
   'antialiased': createRuleProcessor({
     allMatch: {
       '-webkit-font-smoothing': 'antialiased',
@@ -114,11 +116,31 @@ const transformer: Record<string, (v: Record<string, string>) => { transformedRe
       '-webkit-box-orient': 'vertical',
     },
     anyMatch: [
-      { key: '-webkit-line-clamp', pattern: /\d/ },
-      { key: 'line-clamp', pattern: /\d/ },
+      { key: '-webkit-line-clamp', pattern: /^\d+$/ },
+      { key: 'line-clamp', pattern: /^\d+$/ },
     ],
     priority: ['line-clamp', '-webkit-line-clamp'],
     outputTemplate: value => `line-clamp-${value}`,
+  }),
+
+  // eslint-disable-next-line no-template-curly-in-string
+  'line-clamp-${custom}': createRuleProcessor({
+    allMatch: {
+      'overflow': 'hidden',
+      'display': '-webkit-box',
+      '-webkit-box-orient': 'vertical',
+    },
+    anyMatch: [
+      { key: '-webkit-line-clamp', pattern: /^var\(--/ },
+      { key: 'line-clamp', pattern: /^var\(--/ },
+    ],
+    priority: ['line-clamp', '-webkit-line-clamp'],
+    outputTemplate: (value, isV4) => {
+      const customProperty = getCustomPropertyName(value)
+      if (isV4 && customProperty)
+        return `line-clamp-(${customProperty})`
+      return `line-clamp${getVal(value)}`
+    },
   }),
 
   // eslint-disable-next-line no-template-curly-in-string
@@ -180,7 +202,7 @@ const transformer: Record<string, (v: Record<string, string>) => { transformedRe
 }
 
 // 提前转换一些组合的预设，比如 line-clamp-xxx
-export function transformStyleToTailwindPre(styles: string) {
+export function transformStyleToTailwindPre(styles: string, isV4?: boolean) {
   const preTransformedList = []
   // 需要一次性把所有的key和value都给transformer中处理，完全匹配返回新的结果，并且把使用到的属性从原来的结果中删除
   const styleToObj = styles.split(';').filter(Boolean).reduce((r: Record<string, string>, item) => {
@@ -199,7 +221,7 @@ export function transformStyleToTailwindPre(styles: string) {
   }, {})
 
   for (const key in transformer) {
-    const { transformedResult, deleteKeys } = transformer[key](styleToObj)
+    const { transformedResult, deleteKeys } = transformer[key](styleToObj, isV4)
     if (transformedResult && deleteKeys.length) {
       preTransformedList.push(transformedResult)
       // 删除已经转换的属性

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,6 +168,14 @@ export function isVar(s: string) {
   return s.startsWith('var(--')
 }
 
+export function getCustomPropertyName(s: string) {
+  return s.match(/^var\((--[^),\s]+)\)$/)?.[1]
+}
+
+export function normalizeFraction(s: string) {
+  return s.replace(/\s*\/\s*/g, '/')
+}
+
 export function isSize(s: string) {
   return cssMathFnRE.test(s) || numberWithUnitRE.test(s) || positionMap.includes(s)
 }

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -30,7 +30,7 @@ describe('transform', () => {
 
   it('transform: rotate(0deg);', () => {
     expect(toTailwindcss('transform: rotate( 0deg );')).toBe(
-      'rotate-x-[0deg] rotate-y-[0deg]',
+      'rotate-[0deg]',
     )
   })
 
@@ -62,9 +62,7 @@ describe('transform', () => {
   })
 
   it('transform: skew(50deg)', () => {
-    expect(toTailwindcss('transform: skew(50deg);')).toBe(
-      'skew-x-[50deg] skew-y-[50deg]',
-    )
+    expect(toTailwindcss('transform: skew(50deg);')).toBe('skew-x-[50deg]')
   })
 
   it('transform: scale(0.6)', () => {
@@ -81,12 +79,12 @@ describe('transform', () => {
         'transform: translate(-26px, 16px) skew(50deg) scaleY(0.6)',
       ),
     ).toBe(
-      'translate-x-[-26px] translate-y-[16px] skew-x-[50deg] skew-y-[50deg] scale-y-[60%]',
+      'translate-x-[-26px] translate-y-[16px] skew-x-[50deg] scale-y-[60%]',
     )
   })
   it('transform: translate(-26px, var(--translatey)) skew(var(--skew,60)) scaleY(var(--scale));', () => {
     expect(
       toTailwindcss('transform: translate(-26px, var(--translatey,20px)) skew(var(--skew,60)) scale(var(--scale, 30%))'),
-    ).toBe('translate-x-[-26px] translate-y-[var(--translatey,20px)] skew-x-[var(--skew,60)] skew-y-[var(--skew,60)] scale-[var(--scale,30%)]')
+    ).toBe('translate-x-[-26px] translate-y-[var(--translatey,20px)] skew-x-[var(--skew,60)] scale-[var(--scale,30%)]')
   })
 })

--- a/test/v4.test.ts
+++ b/test/v4.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { toTailwindcss } from '../src/toTailwindcss'
+import { transformStyleToTailwindcss } from '../src/transformStyleToTailwindcss'
+
+describe('tailwind v4', () => {
+  it('aspect-ratio utilities', () => {
+    expect(toTailwindcss('aspect-ratio: 1 / 1;', false, true)).toBe('aspect-square')
+    expect(toTailwindcss('aspect-ratio: 3 / 2;', false, true)).toBe('aspect-3/2')
+    expect(toTailwindcss('aspect-ratio: var(--aspect-video);', false, true)).toBe('aspect-video')
+    expect(toTailwindcss('aspect-ratio: var(--my-aspect);', false, true)).toBe('aspect-(--my-aspect)')
+  })
+
+  it('sizing utilities', () => {
+    expect(toTailwindcss('width: 100%;', false, true)).toBe('w-full')
+    expect(toTailwindcss('height: 100vh;', false, true)).toBe('h-screen')
+    expect(toTailwindcss('inline-size: 100%;', false, true)).toBe('inline-full')
+    expect(toTailwindcss('block-size: 100vh;', false, true)).toBe('block-screen')
+    expect(toTailwindcss('min-inline-size: 100%;', false, true)).toBe('min-inline-full')
+    expect(toTailwindcss('max-block-size: 100vh;', false, true)).toBe('max-block-screen')
+  })
+
+  it('typography utilities', () => {
+    expect(toTailwindcss('font-stretch: condensed;', false, true)).toBe('font-stretch-condensed')
+    expect(toTailwindcss('font-stretch: var(--my-stretch);', false, true)).toBe('font-stretch-(--my-stretch)')
+    expect(toTailwindcss('font-feature-settings: \"cv02\", \"cv03\";', false, true)).toBe('font-features-["cv02","cv03"]')
+    expect(toTailwindcss('line-clamp: 3;', false, true)).toBe('line-clamp-3')
+    expect(toTailwindcss('line-clamp: var(--my-lines);', false, true)).toBe('line-clamp-(--my-lines)')
+    expect(toTailwindcss('text-shadow: none;', false, true)).toBe('text-shadow-none')
+    expect(toTailwindcss('text-shadow: 1px 1px 2px rgb(0, 0, 0);', false, true)).toBe('text-shadow-[1px_1px_2px_rgb(0,0,0)]')
+  })
+
+  it('transform utilities', () => {
+    expect(toTailwindcss('perspective-origin: top right;', false, true)).toBe('perspective-origin-top-right')
+    expect(toTailwindcss('rotate: 45deg;', false, true)).toBe('rotate-45')
+    expect(toTailwindcss('transform: rotate(45deg);', false, true)).toBe('rotate-45')
+    expect(toTailwindcss('transform: scale(.5);', false, true)).toBe('scale-50')
+    expect(toTailwindcss('transform: translateX(100%);', false, true)).toBe('translate-x-full')
+    expect(toTailwindcss('transform: skewX(12deg);', false, true)).toBe('skew-x-12')
+    expect(toTailwindcss('translate: 100% 100%;', false, true)).toBe('translate-full')
+  })
+
+  it('interactivity utilities', () => {
+    expect(toTailwindcss('color-scheme: light dark;', false, true)).toBe('scheme-light-dark')
+  })
+
+  it('combined line-clamp preset', () => {
+    expect(
+      transformStyleToTailwindcss(
+        `overflow: hidden;
+display: -webkit-box;
+-webkit-box-orient: vertical;
+line-clamp: var(--my-lines);`,
+        false,
+        false,
+        true,
+      )[0],
+    ).toBe('line-clamp-(--my-lines)')
+  })
+})


### PR DESCRIPTION
## Summary
- add an `isV4` option to the public conversion APIs
- align conversion output with Tailwind v4 utility/property docs for covered categories
- add v4-focused tests and README usage examples

## Verification
- pnpm run ci